### PR TITLE
パスワード表示・非表示

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,5 @@
 //= link_directory ../stylesheets .css
 //= link_tree ../builds
 //= link places.js
+//= link toggle_password.js
+//= link application.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,1 @@
+//= require toggle_password

--- a/app/assets/javascripts/toggle_password.js
+++ b/app/assets/javascripts/toggle_password.js
@@ -1,0 +1,20 @@
+document.addEventListener("DOMContentLoaded", function() {
+  document.querySelectorAll(".toggle-password").forEach(function(icon) {
+    icon.addEventListener("click", function() {
+      // 兄弟要素の input.password-field を探す
+      var input = icon.parentElement.querySelector(".password-field");
+      if (!input) return;
+      // タイプ切り替え
+      var newType = input.type === "password" ? "text" : "password";
+      input.type = newType;
+      // アイコンの見た目を切り替え
+      if (newType === "text") {
+        icon.classList.remove("fa-eye");
+        icon.classList.add("fa-eye-slash");
+      } else {
+        icon.classList.remove("fa-eye-slash");
+        icon.classList.add("fa-eye");
+      }
+    });
+  });
+});

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -23,12 +23,18 @@
 
       <div class="mb-6">
         <%= f.label :password, "新しいパスワード", class: "block mb-1 font-semibold" %>
-        <%= f.password_field :password, autofocus: true, id: "password_password", class: "w-full px-4 py-2 rounded border bg-white", autocomplete: "new-password" %>
+        <div class="relative">
+          <%= f.password_field :password, autofocus: true, id: "password_password", class: "w-full px-4 py-2 pr-10 rounded border bg-white password-field", autocomplete: "new-password" %>
+          <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
+        </div>
       </div>
 
       <div class="mb-6">
         <%= f.label :password_confirmation, "パスワード（確認）", class: "block mb-1 font-semibold" %>
-        <%= f.password_field :password_confirmation, id: "password_password_confirmation", class: "w-full px-4 py-2 rounded border bg-white", autocomplete: "new-password" %>
+        <div class="relative">
+          <%= f.password_field :password_confirmation, id: "password_password_confirmation", class: "w-full px-4 py-2 pr-10 rounded border bg-white password-field", autocomplete: "new-password" %>
+          <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
+        </div>
       </div>
 
       <%= f.submit 'パスワードを変更する', class: "w-full py-3 bg-primary text-white font-bold rounded-xl shadow hover:bg-primary/80 transition" %>
@@ -47,3 +53,4 @@
     </div>
   </div>
 </main>
+

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -36,10 +36,13 @@
         </p>
       </div>
 
-      <!-- パスワード -->
+      <!-- 新しいパスワード -->
       <div class="mb-6">
         <%= f.label :password, "新しいパスワード（変更する場合のみ）", class: "block mb-1 font-semibold" %>
-        <%= f.password_field :password, autocomplete: "new-password", class: "w-full px-4 py-2 rounded border bg-white" %>
+        <div class="relative">
+          <%= f.password_field :password, autocomplete: "new-password", class: "w-full px-4 py-2 pr-10 rounded border bg-white password-field" %>
+          <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
+        </div>
         <p class="text-xs text-gray-500 mt-1">
           ※6文字以上、英字と数字を含めてください。
         </p>
@@ -48,13 +51,19 @@
       <!-- パスワード確認 -->
       <div class="mb-6">
         <%= f.label :password_confirmation, "新しいパスワード（確認用）", class: "block mb-1 font-semibold" %>
-        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "w-full px-4 py-2 rounded border bg-white" %>
+        <div class="relative">
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "w-full px-4 py-2 pr-10 rounded border bg-white password-field" %>
+          <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
+        </div>
       </div>
 
       <!-- 現在のパスワード -->
       <div class="mb-6">
         <%= f.label :current_password, "現在のパスワード（必須）", class: "block mb-1 font-semibold" %>
-        <%= f.password_field :current_password, autocomplete: "current-password", class: "w-full px-4 py-2 rounded border bg-white" %>
+        <div class="relative">
+          <%= f.password_field :current_password, autocomplete: "current-password", class: "w-full px-4 py-2 pr-10 rounded border bg-white password-field" %>
+          <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
+        </div>
         <p class="text-xs text-gray-500 mt-1">
           ※パスワードやメールアドレスを変更する場合は現在のパスワードが必要です。
         </p>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -26,12 +26,18 @@
 
       <div class="mb-6">
         <%= f.label :password, 'パスワード（6文字以上、英数字両方を含める）', class: "block mb-1 font-semibold" %>
-        <%= f.password_field :password, id: "user_password", class: "w-full px-4 py-2 rounded border bg-white", placeholder: "例）abcde1", autocomplete: "new-password" %>
+        <div class="relative">
+          <%= f.password_field :password, id: "user_password", class: "w-full px-4 py-2 pr-10 rounded border bg-white password-field", placeholder: "例）abcde1", autocomplete: "new-password" %>
+          <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
+        </div>
       </div>
 
       <div class="mb-6">
         <%= f.label :password_confirmation, '確認用パスワード', class: "block mb-1 font-semibold" %>
-        <%= f.password_field :password_confirmation, id: "user_password_confirmation", class: "w-full px-4 py-2 rounded border bg-white", autocomplete: "new-password" %>
+        <div class="relative">
+          <%= f.password_field :password_confirmation, id: "user_password_confirmation", class: "w-full px-4 py-2 pr-10 rounded border bg-white password-field", autocomplete: "new-password" %>
+          <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
+        </div>
       </div>
 
       <%= f.submit '新規登録', class: "w-full py-3 bg-primary text-white font-bold rounded-xl shadow hover:bg-primary/80 transition" %>
@@ -44,3 +50,4 @@
     </div>
   </div>
 </main>
+

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -23,7 +23,10 @@
       </div>
       <div class="mb-6">
         <%= f.label :password, 'パスワード', class: "block mb-1 font-semibold" %>
-        <%= f.password_field :password, id: "session_password", class: "w-full px-4 py-2 rounded border bg-white", autocomplete: "current-password" %>
+        <div class="relative">
+          <%= f.password_field :password, id: "session_password", class: "w-full px-4 py-2 pr-10 rounded border bg-white password-field", autocomplete: "current-password" %>
+          <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
+        </div>
       </div>
       <%= f.submit 'ログイン', class: "w-full py-3 bg-primary text-white font-bold rounded-xl shadow hover:bg-primary/80 transition" %>
     <% end %>
@@ -41,3 +44,4 @@
     </div>
   </div>
 </main>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload" %>
   </head>
 
   <body class="font-sans">


### PR DESCRIPTION
ユーザーがパスワード入力中に文字列を確認できるようパスワード表示機能をJSで実装しました。
パスワード入力フォームの右端にある目のアイコンを押すことでとパスワードの表示・非表示を操作できます。
application.html.erbでこのアクションを定義しているのでアプリ内のすべてのパスワード入力フォームがあるところでこの機能が適用されます。


Clloses #60 
