### PR TITLE
ボタンdisabled化

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,3 @@
 //= require toggle_password
 //= require flash
+//= require disabled

--- a/app/assets/javascripts/disabled.js
+++ b/app/assets/javascripts/disabled.js
@@ -1,0 +1,269 @@
+(function() {
+  function setBtnDisabled(btn, disabled, busyText) {
+    if (!btn) return;
+    if (!btn.dataset.label) btn.dataset.label = btn.value || btn.textContent;
+    btn.disabled = !!disabled;
+    if (disabled && busyText) {
+      if ('value' in btn) btn.value = busyText; else btn.textContent = busyText;
+    } else {
+      if ('value' in btn) btn.value = btn.dataset.label; else btn.textContent = btn.dataset.label;
+    }
+  }
+
+  // ===== 新規登録 =====
+  function initSignup() {
+    const form  = document.getElementById("signup-form");
+    if (!form) return; // ページに無ければ何もしない
+
+    const btn   = document.getElementById("signup-submit");
+    const name  = document.getElementById("user_nickname");
+    const email = document.getElementById("user_email");
+    const pw    = document.getElementById("user_password");
+    const pw2   = document.getElementById("user_password_confirmation");
+
+    function pwComplexOK(s){ return /[A-Za-z]/.test(s) && /\d/.test(s); }
+
+    function applyCustomValidity() {
+      if (pw)  pw.setCustomValidity(pwComplexOK(pw.value) ? "" : "英字と数字の両方を含めてください");
+      if (pw && pw2) pw2.setCustomValidity(pw.value === pw2.value ? "" : "パスワードが一致しません");
+    }
+
+    function update() {
+      if (!btn) return;
+      applyCustomValidity();
+      // ネイティブ検証結果に合わせて有効化
+      setBtnDisabled(btn, !form.checkValidity());
+    }
+
+    // 入力のたびに更新（input/change/keyup まで拾って堅牢に）
+    [name, email, pw, pw2].forEach(el => {
+      if (!el) return;
+      ["input","change","keyup"].forEach(ev => el.addEventListener(ev, update));
+    });
+
+    // オートフィル対策：少し遅らせて初回実行
+    setTimeout(update, 0);
+
+    form.addEventListener("submit", (e) => {
+      applyCustomValidity();
+      if (!form.checkValidity()) {
+        e.preventDefault();
+        form.reportValidity();
+        return;
+      }
+      setBtnDisabled(btn, true, "送信中…");
+    });
+  }
+
+  // ===== ログイン =====
+  function initLogin() {
+    const form  = document.getElementById("login-form");
+    if (!form) return;
+
+    const btn   = document.getElementById("login-submit");
+    const email = document.getElementById("session_email");
+    const pw    = document.getElementById("session_password");
+
+    function update() {
+      if (!btn) return;
+      setBtnDisabled(btn, !form.checkValidity());
+    }
+
+    [email, pw].forEach(el => {
+      if (!el) return;
+      ["input","change","keyup"].forEach(ev => el.addEventListener(ev, update));
+    });
+
+    setTimeout(update, 0);
+
+    form.addEventListener("submit", (e) => {
+      if (!form.checkValidity()) {
+        e.preventDefault();
+        form.reportValidity();
+        return;
+      }
+      setBtnDisabled(btn, true, "送信中…");
+    });
+  }
+
+// ===== お問い合わせ =====
+  function initContact() {
+    const form = document.getElementById("contact-form");
+    if (!form) return;
+
+    const btn  = document.getElementById("contact-submit");
+    const name = form.querySelector('input[name="name"]');
+    const mail = form.querySelector('input[name="email"]');
+    const msg  = form.querySelector('textarea[name="message"]');
+
+    // 念のため required を担保
+    [name, mail, msg].forEach(el => el && el.setAttribute("required", ""));
+
+    function update() {
+      if (!btn) return;
+      setBtnDisabled(btn, !form.checkValidity());
+    }
+
+    [name, mail, msg].forEach(el => el && ["input","change","keyup"].forEach(ev => el.addEventListener(ev, update)));
+    setTimeout(update, 0);
+
+    form.addEventListener("submit", (e) => {
+      if (!form.checkValidity()) {
+        e.preventDefault();
+        form.reportValidity();
+        return;
+      }
+      setBtnDisabled(btn, true, "送信中…");
+    });
+  }
+
+  // ===== アカウント設定（メール/パスワード変更） =====
+  function initAccount() {
+    const form = document.getElementById("account-form");
+    if (!form) return;
+
+    const btn   = document.getElementById("account-submit");
+    const email = document.getElementById("account_email");
+    const pw    = document.getElementById("account_new_password");
+    const pw2   = document.getElementById("account_new_password_confirmation");
+    const cur   = document.getElementById("account_current_password");
+
+    function pwOK(s){ return /[A-Za-z]/.test(s) && /\d/.test(s) && s.length >= 6; }
+    function emailChanged() {
+      if (!email) return false;
+      const original = email.dataset.original || "";
+      return (email.value || "").trim() !== original.trim();
+    }
+    function wantsPwChange() {
+      return !!(pw && pw.value.length > 0);
+    }
+    function somethingWillChange() {
+      return emailChanged() || wantsPwChange();
+    }
+
+    function applyCustomValidity() {
+      // 何か変更するなら current_password 必須
+      if (cur) {
+        cur.setCustomValidity(somethingWillChange() && !cur.value ? "現在のパスワードを入力してください" : "");
+      }
+      // パスワードを変えるなら複雑性＆一致
+      if (wantsPwChange()) {
+        pw.setCustomValidity(pwOK(pw.value) ? "" : "6文字以上で英字と数字を含めてください");
+        if (pw2) pw2.setCustomValidity(pw.value === pw2.value ? "" : "パスワードが一致しません");
+      } else {
+        pw.setCustomValidity("");
+        if (pw2) pw2.setCustomValidity("");
+      }
+    }
+
+    function update() {
+      if (!btn) return;
+      applyCustomValidity();
+
+      // 何も変更しない場合は押せない
+      const canSubmit = somethingWillChange() && form.checkValidity();
+      setBtnDisabled(btn, !canSubmit);
+    }
+
+    [email, pw, pw2, cur].forEach(el => el && ["input","change","keyup"].forEach(ev => el.addEventListener(ev, update)));
+    setTimeout(update, 0);
+
+    form.addEventListener("submit", (e) => {
+      applyCustomValidity();
+      const canSubmit = somethingWillChange() && form.checkValidity();
+      if (!canSubmit) {
+        e.preventDefault();
+        form.reportValidity();
+        return;
+      }
+      setBtnDisabled(btn, true, "保存中…");
+    });
+  }
+
+  // ==== パスワードリセット申請 ====
+  function initPasswordRequest() {
+    const form = document.getElementById("password-request-form");
+    if (!form) return;
+
+    const btn   = document.getElementById("password-request-submit");
+    const email = document.getElementById("password_email");
+
+    // 念のため required を担保
+    if (email) email.setAttribute("required", "");
+
+    function update() {
+      if (!btn) return;
+      btn.disabled = !form.checkValidity();
+    }
+
+    ["input","change","keyup"].forEach(ev => email && email.addEventListener(ev, update));
+    setTimeout(update, 0);
+
+    form.addEventListener("submit", (e) => {
+      if (!form.checkValidity()) {
+        e.preventDefault();
+        form.reportValidity();
+        return;
+      }
+      if (!btn.dataset.label) btn.dataset.label = btn.value || btn.textContent;
+      btn.disabled = true;
+      if ('value' in btn) btn.value = "送信中…"; else btn.textContent = "送信中…";
+    });
+  }
+
+  // ==== パスワード再設定（入力） ====
+  function initPasswordReset() {
+    const form = document.getElementById("password-reset-form");
+    if (!form) return;
+
+    const btn  = document.getElementById("password-reset-submit");
+    const pw   = document.getElementById("password_password");
+    const pw2  = document.getElementById("password_password_confirmation");
+
+    const minLen = Number((pw && pw.dataset.minlen) || 6);
+
+    function pwOK(s){ return /[A-Za-z]/.test(s) && /\d/.test(s) && s.length >= minLen; }
+
+    function applyValidity() {
+      if (pw)  pw.setCustomValidity(pwOK(pw.value) ? "" : `英字と数字を含み、${minLen}文字以上で入力してください`);
+      if (pw && pw2) pw2.setCustomValidity(pw.value === pw2.value ? "" : "パスワードが一致しません");
+    }
+
+    function update() {
+      if (!btn) return;
+      applyValidity();
+      btn.disabled = !form.checkValidity();
+    }
+
+    [pw, pw2].forEach(el => el && ["input","change","keyup"].forEach(ev => el.addEventListener(ev, update)));
+    setTimeout(update, 0);
+
+    form.addEventListener("submit", (e) => {
+      applyValidity();
+      if (!form.checkValidity()) {
+        e.preventDefault();
+        form.reportValidity();
+        return;
+      }
+      if (!btn.dataset.label) btn.dataset.label = btn.value || btn.textContent;
+      btn.disabled = true;
+      if ('value' in btn) btn.value = "変更中…"; else btn.textContent = "変更中…";
+    });
+  }
+
+  // ==== 既存 initAll にフックを追加 ====
+  function initAll() {
+    // 既存: initSignup(); initLogin(); initContact(); initAccount();
+    if (typeof initSignup === "function") initSignup();
+    if (typeof initLogin  === "function") initLogin();
+    if (typeof initContact === "function") initContact();
+    if (typeof initAccount === "function") initAccount();
+    // 新規
+    initPasswordRequest();
+    initPasswordReset();
+  }
+
+  document.addEventListener("turbo:load", initAll);
+  document.addEventListener("DOMContentLoaded", initAll);
+
+})();

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -8,19 +8,19 @@
     <div class="mb-4 p-3 bg-green-100 text-green-700 rounded"><%= notice %></div>
   <% end %>
 
-  <%= form_with url: contact_path, local: true do |f| %>
+  <%= form_with url: contact_path, local: true, html: { id: "contact-form", novalidate: true } do |f| %>
     <div class="mb-4">
       <%= label_tag :name, "お名前", class: "block font-bold mb-1" %>
-      <%= text_field_tag :name, params[:name], class: "w-full border rounded px-3 py-2" %>
+      <%= text_field_tag :name, params[:name], required: true, class: "w-full border rounded px-3 py-2" %>
     </div>
     <div class="mb-4">
       <%= label_tag :email, "メールアドレス", class: "block font-bold mb-1" %>
-      <%= email_field_tag :email, params[:email], class: "w-full border rounded px-3 py-2" %>
+      <%= email_field_tag :email, params[:email], required: true, class: "w-full border rounded px-3 py-2" %>
     </div>
     <div class="mb-4">
       <%= label_tag :message, "お問い合わせ内容", class: "block font-bold mb-1" %>
-      <%= text_area_tag :message, params[:message], rows: 6, class: "w-full border rounded px-3 py-2" %>
+      <%= text_area_tag :message, params[:message], rows: 6, required: true, minlength: 5, class: "w-full border rounded px-3 py-2" %>
     </div>
-    <%= submit_tag "送信する", class: "w-full bg-secondary text-white py-2 rounded hover:bg-secondary/80" %>
+    <%= submit_tag "送信する", id: "contact-submit", disabled: true, class: "w-full bg-secondary text-white py-2 rounded hover:bg-secondary/80 disabled:opacity-50 disabled:cursor-not-allowed" %>
   <% end %>
 </div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,3 +1,6 @@
+<% min_len = resource_class.password_length.min %>
+<% max_len = resource_class.password_length.max %>
+
 <main class="flex justify-center items-center px-4 mt-10">
   <div class="w-full max-w-md p-8 rounded-xl border border-gray-200 shadow-sm">
     <!-- タイトル -->
@@ -18,13 +21,13 @@
     <% end %>
 
     <!-- パスワード再設定フォーム -->
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { id: "password-reset-form", method: :put, novalidate: true }) do |f| %>
       <%= f.hidden_field :reset_password_token %>
 
       <div class="mb-6">
         <%= f.label :password, "新しいパスワード", class: "block mb-1 font-bold text-secondary" %>
         <div class="relative">
-          <%= f.password_field :password, autofocus: true, id: "password_password", class: "w-full px-4 py-2 pr-10 rounded border password-field", autocomplete: "new-password" %>
+          <%= f.password_field :password, id: "password_password", required: true, minlength: min_len, maxlength: max_len, data: { minlen: min_len }, class: "w-full px-4 py-2 pr-10 rounded border password-field", autocomplete: "new-password", autofocus: true %>
           <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
         </div>
       </div>
@@ -32,12 +35,12 @@
       <div class="mb-6">
         <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block mb-1 font-bold text-secondary" %>
         <div class="relative">
-          <%= f.password_field :password_confirmation, id: "password_password_confirmation", class: "w-full px-4 py-2 pr-10 rounded border password-field", autocomplete: "new-password" %>
+          <%= f.password_field :password_confirmation, id: "password_password_confirmation", required: true, class: "w-full px-4 py-2 pr-10 rounded border password-field", autocomplete: "new-password" %>
           <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
         </div>
       </div>
 
-      <%= f.submit 'パスワードを変更する', class: "w-full py-3 mt-6 bg-primary text-white font-bold rounded-xl shadow hover:bg-primary/80 transition" %>
+      <%= f.submit 'パスワードを変更する', id: "password-reset-submit", disabled: true, class: "w-full py-3 mt-6 bg-primary text-white font-bold rounded-xl shadow hover:bg-primary/80 transition disabled:opacity-50 disabled:cursor-not-allowed" %>
     <% end %>
 
     <!-- ログイン・新規登録リンク -->

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -22,16 +22,16 @@
     <% end %>
 
     <!-- メールアドレス入力フォーム -->
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { id: "password-request-form", method: :post, novalidate: true }) do |f| %>
       <div class="mb-6">
         <%= f.label :email, 'メールアドレスを入力してください', class: "block mb-1 font-bold text-secondary" %>
-        <%= f.email_field :email, autofocus: true, id: "password_email", class: "w-full px-4 py-2 rounded border", autocomplete: "email" %>
+        <%= f.email_field :email, id: "password_email", required: true, autofocus: true, id: "password_email", class: "w-full px-4 py-2 rounded border", autocomplete: "email" %>
         <p class="text-xs text-gray-500 mt-1">
           ※登録済みのメールアドレスを入力してください。<br>
           ※申請するとメールが届きます。メール内のリンクから新しいパスワードを設定してください。
         </p>
       </div>
-      <%= f.submit '申請する', class: "w-full py-3 mt-6 bg-primary text-white font-bold rounded-xl shadow hover:bg-primary/80 transition" %>
+      <%= f.submit '申請する', id: "password-request-submit", disabled: true, class: "w-full py-3 mt-6 bg-primary text-white font-bold rounded-xl shadow hover:bg-primary/80 transition disabled:opacity-50 disabled:cursor-not-allowed" %>
     <% end %>
 
     <!-- ログイン・新規登録リンク -->

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -25,12 +25,12 @@
     <% end %>
 
     <!-- 編集フォーム -->
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { id: "account-form", method: :put, novalidate: true }) do |f| %>
 
       <!-- メールアドレス -->
       <div class="mb-6">
         <%= f.label :email, "メールアドレス", class: "block mb-1 font-bold text-secondary" %>
-        <%= f.email_field :email, autofocus: true, class: "w-full px-4 py-2 rounded border", autocomplete: "email" %>
+        <%= f.email_field :email, id: "account_email", value: resource.email, data: { original: resource.email }, class: "w-full px-4 py-2 rounded border", autocomplete: "email" %>
         <p class="text-xs text-gray-500 mt-1">
           ※メールアドレスを変更すると確認メールが届きます。メール内のリンクから新しいメールアドレスの確認を完了させてください。
         </p>
@@ -40,7 +40,7 @@
       <div class="mb-6 text-[15px] md:text-base">
         <%= f.label :password, "新しいパスワード（変更する場合のみ）", class: "block mb-1 font-bold text-secondary" %>
         <div class="relative">
-          <%= f.password_field :password, autocomplete: "new-password", class: "w-full px-4 py-2 pr-10 rounded border password-field" %>
+          <%= f.password_field :password, id: "account_new_password", autocomplete: "new-password", class: "w-full px-4 py-2 pr-10 rounded border password-field" %>
           <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
         </div>
         <p class="text-xs text-gray-500 mt-1">
@@ -52,7 +52,7 @@
       <div class="mb-6">
         <%= f.label :password_confirmation, "新しいパスワード（確認用）", class: "block mb-1 font-bold text-secondary" %>
         <div class="relative">
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "w-full px-4 py-2 pr-10 rounded border password-field" %>
+          <%= f.password_field :password_confirmation, id: "account_new_password_confirmation", autocomplete: "new-password", class: "w-full px-4 py-2 pr-10 rounded border password-field" %>
           <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
         </div>
       </div>
@@ -61,7 +61,7 @@
       <div class="mb-6">
         <%= f.label :current_password, "現在のパスワード（必須）", class: "block mb-1 font-bold text-secondary" %>
         <div class="relative">
-          <%= f.password_field :current_password, autocomplete: "current-password", class: "w-full px-4 py-2 pr-10 rounded border password-field" %>
+          <%= f.password_field :current_password, id: "account_current_password", autocomplete: "current-password", class: "w-full px-4 py-2 pr-10 rounded border password-field" %>
           <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
         </div>
         <p class="text-xs text-gray-500 mt-1">
@@ -70,7 +70,7 @@
       </div>
 
       <!-- 送信ボタン -->
-      <%= f.submit "変更を保存する", class: "w-full py-3 mt-6 bg-primary text-white font-bold rounded-xl shadow hover:bg-primary/80 transition" %>
+      <%= f.submit "変更を保存する", id: "account-submit", disabled: true, class: "w-full py-3 mt-6 bg-primary text-white font-bold rounded-xl shadow hover:bg-primary/80 transition disabled:opacity-50 disabled:cursor-not-allowed" %>
     <% end %>
 
     <!-- リンク -->

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,6 @@
+<% min_len = resource_class.password_length.min %>
+<% max_len = resource_class.password_length.max %>
+
 <main class="flex justify-center items-center px-4 mt-10">
   <div class="w-full max-w-md p-8 rounded-xl border border-gray-200 shadow-sm">
     <!-- タイトル -->
@@ -13,15 +16,15 @@
     <% end %>
 
     <!-- 入力フォーム -->
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { id: "signup-form", novalidate: true }) do |f| %>
       <div class="mb-6">
         <%= f.label :nickname, 'ニックネーム', class: "block mb-1 font-bold text-secondary" %>
-        <%= f.text_field :nickname, id: "user_nickname", class: "w-full px-4 py-2 rounded border", placeholder: "例）たろう", autocomplete: "nickname", autofocus: true %>
+        <%= f.text_field :nickname, id: "user_nickname", required: true, maxlength: 50, class: "w-full px-4 py-2 rounded border", placeholder: "例）たろう", autocomplete: "nickname", autofocus: true %>
       </div>
 
       <div class="mb-6">
         <%= f.label :email, 'メールアドレス', class: "block mb-1 font-bold text-secondary" %>
-        <%= f.email_field :email, id: "user_email", class: "w-full px-4 py-2 rounded border", placeholder: "例）taro@example.com", autocomplete: "email" %>
+        <%= f.email_field :email, id: "user_email", required: true, class: "w-full px-4 py-2 rounded border", placeholder: "例）taro@example.com", autocomplete: "email" %>
         <p class="text-xs text-gray-500 mt-1">
           ※登録のため本人確認メールが届きます。メール内のリンクからアカウントを有効化させてください。
         </p>
@@ -31,11 +34,11 @@
         <%= f.label :password, class: "block mb-1 font-bold text-secondary" do %>
           パスワード
           <span class="md:ml-2 text-xs text-gray-500">
-          ※6文字以上、英数字両方を含める
+          ※<%= min_len %>文字以上、英数字両方を含める
           </span>
         <% end %>
         <div class="relative">
-          <%= f.password_field :password, id: "user_password", class: "w-full px-4 py-2 pr-10 rounded border password-field", placeholder: "例）abcd12", autocomplete: "new-password" %>
+          <%= f.password_field :password, id: "user_password", required: true, minlength: min_len, maxlength: max_len, class: "w-full px-4 py-2 pr-10 rounded border password-field", placeholder: "例）abcd12", autocomplete: "new-password" %>
           <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
         </div>
       </div>
@@ -43,12 +46,12 @@
       <div class="mb-6">
         <%= f.label :password_confirmation, '確認用パスワード', class: "block mb-1 font-bold text-secondary" %>
         <div class="relative">
-          <%= f.password_field :password_confirmation, id: "user_password_confirmation", class: "w-full px-4 py-2 pr-10 rounded border password-field", autocomplete: "new-password" %>
+          <%= f.password_field :password_confirmation, id: "user_password_confirmation", required: true, class: "w-full px-4 py-2 pr-10 rounded border password-field", autocomplete: "new-password" %>
           <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
         </div>
       </div>
 
-      <%= f.submit '新規登録', class: "w-full py-3 mt-6 bg-primary text-white font-bold rounded-xl shadow hover:bg-primary/80 transition animate-breath" %>
+      <%= f.submit '新規登録', id: "signup-submit", disabled: true, class: "w-full py-3 mt-6 bg-primary text-white font-bold rounded-xl shadow hover:bg-primary/80 transition animate-breath disabled:opacity-50 disabled:cursor-not-allowed" %>
     <% end %>
 
     <!-- 会員登録済みの方の導線 -->

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,19 +16,20 @@
     <% end %>
 
     <!-- 入力フォーム -->
-    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { id: "login-form", novalidate: true }) do |f| %>
       <div class="mb-6">
         <%= f.label :email, 'メールアドレス', class: "block mb-1 font-bold text-secondary" %>
-        <%= f.email_field :email, autofocus: true, id: "session_email", class: "w-full px-4 py-2 rounded border", autocomplete: "email" %>
+        <%= f.email_field :email, id: "session_email", required: true, class: "w-full px-4 py-2 rounded border", autocomplete: "email", autofocus: true %>
       </div>
       <div class="mb-6">
         <%= f.label :password, 'パスワード', class: "block mb-1 font-bold text-secondary" %>
         <div class="relative">
-          <%= f.password_field :password, id: "session_password", class: "w-full px-4 py-2 pr-10 rounded border password-field", autocomplete: "current-password" %>
+          <%= f.password_field :password, id: "session_password", required: true, class: "w-full px-4 py-2 pr-10 rounded border password-field", autocomplete: "current-password" %>
           <i class="fa-solid fa-eye absolute top-1/2 right-3 transform -translate-y-1/2 cursor-pointer toggle-password text-gray-400"></i>
         </div>
       </div>
-      <%= f.submit 'ログイン', class: "w-full py-3 mt-6 bg-secondary text-white font-bold rounded-xl shadow hover:bg-secondary/80 transition" %>
+
+      <%= f.submit 'ログイン', id: "login-submit", disabled: true, class: "w-full py-3 mt-6 bg-secondary text-white font-bold rounded-xl shadow hover:bg-secondary/80 transition disabled:opacity-50 disabled:cursor-not-allowed" %>
     <% end %>
 
     <!-- パスワードリセット・新規会員登録への導線 -->


### PR DESCRIPTION
新規登録、ログイン、お問い合わせ、アカウント設定変更、パスワードリセット申請、パスワード再設定入力
それぞれのページにある送信ボタンをdisabled化しました。
これで入力フォームの必要な項目が埋まっていなかったり、送信中時はボタンが押せないようになりました。

ビュー：各ページの<form>に id / novalidate、各項目に required、submit に id + disabled + 見た目クラスを追加。
JS：disabled.js を追加し、ページごとに initXXX( ) を用意。

Closes #64