### PR TITLE
抽選ロジックをServiceへ

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -26,14 +26,9 @@ Layout/ArgumentAlignment:
 # This cop supports safe autocorrection (--autocorrect).
 Layout/ElseAlignment:
   Exclude:
-    - 'app/controllers/main_controller.rb'
 
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
-Layout/EmptyLineAfterGuardClause:
-  Exclude:
-    - 'app/models/budget.rb'
-    - 'app/models/user.rb'
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
@@ -63,7 +58,6 @@ Layout/EmptyLinesAroundBlockBody:
 # SupportedStylesAlignWith: keyword, variable, start_of_line
 Layout/EndAlignment:
   Exclude:
-    - 'app/controllers/main_controller.rb'
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
@@ -71,7 +65,6 @@ Layout/EndAlignment:
 Layout/ExtraSpacing:
   Exclude:
     - 'app/controllers/application_controller.rb'
-    - 'app/controllers/main_controller.rb'
     - 'app/controllers/users/registrations_controller.rb'
 
 # Offense count: 2
@@ -99,14 +92,11 @@ Layout/HashAlignment:
 Layout/IndentationWidth:
   Exclude:
     - 'app/controllers/budgets_controller.rb'
-    - 'app/controllers/main_controller.rb'
 
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
 # URISchemes: http, https
-Layout/LineLength:
-  Max: 154
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
@@ -132,7 +122,6 @@ Layout/SpaceInsideArrayLiteralBrackets:
 # SupportedStyles: space, compact, no_space
 Layout/SpaceInsideParens:
   Exclude:
-    - 'app/controllers/main_controller.rb'
 
 # Offense count: 6
 # This cop supports safe autocorrection (--autocorrect).
@@ -165,7 +154,6 @@ Layout/TrailingWhitespace:
   Exclude:
     - 'Gemfile'
     - 'app/controllers/application_controller.rb'
-    - 'app/controllers/main_controller.rb'
     - 'app/controllers/static_controller.rb'
     - 'app/controllers/users/omniauth_callbacks_controller.rb'
     - 'app/models/budget.rb'
@@ -190,7 +178,6 @@ Lint/UnusedMethodArgument:
 # Configuration parameters: AutoCorrect.
 Lint/UselessAssignment:
   Exclude:
-    - 'app/controllers/main_controller.rb'
 
 # Offense count: 16
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
@@ -307,7 +294,6 @@ Rails/I18nLocaleTexts:
     - 'app/controllers/budgets_controller.rb'
     - 'app/controllers/contacts_controller.rb'
     - 'app/controllers/draws_controller.rb'
-    - 'app/controllers/main_controller.rb'
     - 'app/controllers/users/omniauth_callbacks_controller.rb'
 
 # Offense count: 2
@@ -362,7 +348,6 @@ Style/ComparableClamp:
 # SupportedStyles: assign_to_condition, assign_inside_condition
 Style/ConditionalAssignment:
   Exclude:
-    - 'app/controllers/main_controller.rb'
     - 'app/mailers/custom_devise_mailer.rb'
 
 # Offense count: 6
@@ -387,19 +372,11 @@ Style/GlobalStdStream:
 # Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.
 Style/GuardClause:
   Exclude:
-    - 'app/controllers/main_controller.rb'
     - 'app/models/budget.rb'
     - 'app/models/user.rb'
 
 # Offense count: 7
 # This cop supports safe autocorrection (--autocorrect).
-Style/IfUnlessModifier:
-  Exclude:
-    - 'app/controllers/budgets_controller.rb'
-    - 'app/controllers/places_controller.rb'
-    - 'app/models/budget.rb'
-    - 'app/models/user.rb'
-    - 'config/routes.rb'
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -418,7 +395,6 @@ Style/OpenStructUse:
 # This cop supports safe autocorrection (--autocorrect).
 Style/ParallelAssignment:
   Exclude:
-    - 'app/controllers/main_controller.rb'
 
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
@@ -489,5 +465,3 @@ Style/TrailingCommaInHashLiteral:
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, IgnoreCopDirectives, AllowedPatterns, SplitStrings.
 # URISchemes: http, https
-Layout/LineLength:
-  Max: 154

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -6,9 +6,7 @@ class BudgetsController < ApplicationController
     year_month = Date.current.strftime("%Y-%m")
     existing_budget = current_user.budget_for(year_month)
 
-    if existing_budget.nil? && params[:from_signup] != '1'
-     return redirect_to new_budget_path(from_signup: '1')
-    end
+    return redirect_to new_budget_path(from_signup: '1') if existing_budget.nil? && params[:from_signup] != '1'
 
     if existing_budget
       redirect_to edit_budget_path

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -35,9 +35,7 @@ class PlacesController < ApplicationController
     body = res.body.to_s.force_encoding("UTF-8")
 
     # デバッグしやすく：エラー時はレスポンス本文をそのまま返す（必要なら削除OK）
-    if res.code.to_i >= 400
-      Rails.logger.error("[Places] #{res.code} #{body}")
-    end
+    Rails.logger.error("[Places] #{res.code} #{body}") if res.code.to_i >= 400
 
     render json: JSON.parse(body), status: res.code.to_i
   rescue JSON::ParserError

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -38,18 +38,16 @@ class Budget < ApplicationRecord
 
   def draw_days_cannot_exceed_days_in_month
     return if draw_days.blank?
+
     total_days = Date.current.end_of_month.day
-    if draw_days.to_i > total_days
-      errors.add(:draw_days, "は今月の日数（#{total_days}日）以内で設定してください")
-    end
+    errors.add(:draw_days, "は今月の日数（#{total_days}日）以内で設定してください") if draw_days.to_i > total_days
   end
 
   def draw_days_changeable
     return unless persisted? && user.present?
+
     used = draws_this_month_count
-    if draw_days.present? && draw_days.to_i < used
-      errors.add(:draw_days, "は、すでにガチャ済みの日数（#{used}回）より少なくはできません")
-    end
+    errors.add(:draw_days, "は、すでにガチャ済みの日数（#{used}回）より少なくはできません") if draw_days.present? && draw_days.to_i < used
   end
 
   def draw_days_within_used_plus_remaining_days

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   # Google経由作成時はパスワード未入力で作成OKにする
   def password_required?
     return false if provider.present? && uid.present? && !password.present?
+
     super
   end
 
@@ -49,8 +50,7 @@ class User < ApplicationRecord
 
   def password_complexity
     return if password.blank?
-    unless password =~ /[a-zA-Z]/ && password =~ /\d/
-      errors.add :password, "は英字と数字の両方を含めてください"
-    end
+
+    errors.add :password, "は英字と数字の両方を含めてください" unless password =~ /[a-zA-Z]/ && password =~ /\d/
   end
 end

--- a/app/services/draw_picker.rb
+++ b/app/services/draw_picker.rb
@@ -1,0 +1,157 @@
+class DrawPicker
+  # マジックナンバーを定数化 金額は10円刻みで WIDH = 幅 WEIGH = 確率
+  INCREMENT = 10
+  WIDTH_LOW = 0.30
+  WIDTH_MID = 0.40
+  WIDTH_HIGH = 0.30
+  WEIGHT_LOW = 0.30
+  WEIGHT_MID = 0.40
+  WEIGHT_HIGH = 0.30
+
+  # メッセージ帯境界を返すための入れ物
+  BandRanges = Struct.new(
+    :low_min, :low_max, :mid_min, :mid_max, :high_min, :high_max,
+    keyword_init: true
+  )
+
+  # 状態初期化 rng テスト用に乱数差し替え可
+  def initialize(min:, max:, remaining_days:, remaining_budget:, rng: ::Kernel)
+    @min = min.to_i
+    @max = max.to_i
+    @remaining_days = remaining_days.to_i
+    @remaining_budget = remaining_budget.to_i
+    @rng = rng
+  end
+
+  # 金額を 1 回分だけ決定して返す
+  def pick
+    min_feasible = [@min, @remaining_budget - (@max * (@remaining_days - 1))].max
+    max_feasible = [@max, @remaining_budget - (@min * (@remaining_days - 1))].min
+
+    # 最終日は残り予算を10円刻みに切り下げ、min/max の実現可能レンジにクランプ
+    if @remaining_days == 1
+      amount = floor_inc(@remaining_budget)
+      return amount.clamp(min_feasible, max_feasible)
+    end
+
+    min10 = ceil_inc(min_feasible)
+    max10 = floor_inc(max_feasible)
+
+    # 10円グリッドに乗らないほど狭い → 近い10円に丸めてクランプ
+    if min10 > max10
+      amount = round_inc(min_feasible)
+      return amount.clamp(min_feasible, max_feasible)
+    end
+
+    # 3帯の幅（tick数）を決める
+    ticks_total = ((max10 - min10) / INCREMENT) + 1
+    low_ticks = [(ticks_total * WIDTH_LOW).floor, 1].max
+    mid_ticks = [(ticks_total * WIDTH_MID).floor, 1].max
+    high_ticks = ticks_total - low_ticks - mid_ticks
+    if high_ticks < 1
+      take = 1 - high_ticks
+      reduce_mid = [take, mid_ticks - 1].min
+      mid_ticks -= reduce_mid
+      take -= reduce_mid
+      low_ticks -= [take, low_ticks - 1].min
+    end
+
+    low_min = min10
+    low_max = low_min + ((low_ticks - 1) * INCREMENT)
+    mid_min = low_max + INCREMENT
+    mid_max = mid_min + ((mid_ticks - 1) * INCREMENT)
+    high_min = mid_max + INCREMENT
+    high_max = max10
+
+    # 確率で帯を選ぶ
+    r = @rng.rand
+    band =
+      if r < WEIGHT_LOW
+        :low
+      elsif r < (WEIGHT_LOW + WEIGHT_MID)
+        :mid
+      else
+        :high
+      end
+
+    # 選ばれた帯から金額を一様に1つ選ぶ
+    range =
+      case band
+      when :low then (low_min <= low_max ? [low_min, low_max] : [min10, max10])
+      when :mid then (mid_min <= mid_max ? [mid_min, mid_max] : [min10, max10])
+      when :high then (high_min <= high_max ? [high_min, high_max] : [min10, max10])
+      end
+
+    amount = pick_from_band(*range)
+    amount.clamp(min_feasible, max_feasible)
+  end
+
+  # index 用：現在設定から帯の境界を算出
+  def bands
+    min_feasible, max_feasible = feasible_range
+
+    min10 = ceil_inc(min_feasible)
+    max10 = floor_inc(max_feasible)
+
+    # グリッドが無いほど狭い場合は全域同一帯
+    if min10 > max10
+      return BandRanges.new(
+        low_min: min10,  low_max: max10,
+        mid_min: min10,  mid_max: max10,
+        high_min: min10, high_max: max10
+      )
+    end
+
+    ticks_total = ((max10 - min10) / INCREMENT) + 1
+
+    low_ticks  = [(ticks_total * WIDTH_LOW).floor, 1].max
+    mid_ticks  = [(ticks_total * WIDTH_MID).floor, 1].max
+    high_ticks =  ticks_total - low_ticks - mid_ticks
+    if high_ticks < 1
+      take = 1 - high_ticks
+      reduce_mid = [take, mid_ticks - 1].min
+      mid_ticks -= reduce_mid
+      take -= reduce_mid
+      low_ticks -= [take, low_ticks - 1].min
+    end
+
+    low_min  = min10
+    low_max  = low_min + ((low_ticks - 1) * INCREMENT)
+    mid_min  = low_max + INCREMENT
+    mid_max  = mid_min + ((mid_ticks - 1) * INCREMENT)
+    high_min = mid_max + INCREMENT
+    high_max = max10
+
+    BandRanges.new(
+      low_min:, low_max:, mid_min:, mid_max:, high_min:, high_max:
+    )
+  end
+
+  # 金額が low/mid/high のどれか判定
+  def classify(amount)
+    r = bands
+    return :low  if amount <= r.low_max
+    return :high if amount >= r.high_min
+
+    :mid
+  end
+
+  private
+
+  # pick/bands 共通の実現可能レンジ
+  def feasible_range
+    min_feasible = [@min, @remaining_budget - (@max * (@remaining_days - 1))].max
+    max_feasible = [@max, @remaining_budget - (@min * (@remaining_days - 1))].min
+    [min_feasible, max_feasible]
+  end
+
+  def ceil_inc(val) = ((val + INCREMENT - 1) / INCREMENT) * INCREMENT
+  def floor_inc(val) = (val / INCREMENT) * INCREMENT
+  def round_inc(val) = (val.to_f / INCREMENT).round * INCREMENT
+
+  def pick_from_band(start_yen, end_yen)
+    ticks = ((end_yen - start_yen) / INCREMENT) + 1
+    idx = @rng.rand(ticks)
+    start_yen + (idx * INCREMENT)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,5 @@ Rails.application.routes.draw do
   get "/terms", to: "static#terms", as: :terms
   get "/privacy", to: "static#privacy", as: :privacy
 
-  if Rails.env.development?
-    mount LetterOpenerWeb::Engine, at: "/letter_opener"
-  end
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
抽選ロジックをServiceへまるまる移動
また一部使用していたマジックナンバーを定数化しました
並行処理対策で with_lock を追加
@draw_message もロジックをServiceに移動。抽選ロジックの価格幅とメッセージ幅を合わせる

.rubocop_todo.yml一部返済
