### PR TITLE
GoogleAnalytics設定

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,37 @@
 
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload" %>
+
+    <% if Rails.env.production? && ENV['GA_MEASUREMENT_ID'].present? %>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GA_MEASUREMENT_ID'] %>"></script>
+      <script>
+        (function () {
+          var GA_ID = '<%= ENV['GA_MEASUREMENT_ID'] %>';
+
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){ dataLayer.push(arguments); }
+          window.gtag = window.gtag || gtag;
+          gtag('js', new Date());
+
+          gtag('config', GA_ID, { send_page_view: false });
+
+          var lastPath = null;
+          function sendPV() {
+            if (!window.gtag) return;
+            var path = location.pathname + location.search;
+            if (path === lastPath) return;
+            lastPath = path;
+            gtag('event', 'page_view', {
+              page_title: document.title,
+              page_location: location.href,
+              page_path: path
+            });
+          }
+          document.addEventListener('DOMContentLoaded', sendPV);
+          document.addEventListener('turbo:load', sendPV);
+        })();
+      </script>
+    <% end %>
   </head>
 
   <body class="font-sans">

--- a/spec/requests/budgets_spec.rb
+++ b/spec/requests/budgets_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe "Budgets", type: :request do
   let(:user) { create(:user) }
 
+  around { |ex| travel_to(Time.zone.local(2025, 1, 15, 12)) { ex.run } }
+
   describe "GET /budget/new" do
     it "未ログインはログインへ" do
       get new_budget_path


### PR DESCRIPTION
ユーザー数、PV数測定のためGoogleAnalyticsを設定しました。
GA4 プロパティを用意
Turbo対応・二重測定防止のためGAの公式JS（gtag）を初期化
初回自動PVを止め手動で送るように設定
・初回ロードは DOMContentLoaded で確実に1回送る
・ページ遷移は Turbo の turbo:load で毎回送る
・直前に送った URL（lastPath）と同じならスキップ（二重測定防止）